### PR TITLE
 Automatically join channels when messages are received / Don't include the hash in the channels' names

### DIFF
--- a/pickups/irc.py
+++ b/pickups/irc.py
@@ -26,6 +26,7 @@ class Client(object):
 
         self.nickname = None
         self.sent_messages = []
+        self.joined_channels = set()
 
     def readline(self):
         return self.reader.readline()
@@ -62,7 +63,8 @@ class Client(object):
 
     def join(self, channel):
         """Tells the client to join a channel."""
-        self.write(self.nickname, 'JOIN', ':{}'.format(channel))
+        self.joined_channels.add(channel)
+        self.write(self.nickname, 'JOIN', channel)
 
     def list_nicks(self, channel, nicks):
         """Tells the client what nicks are in channel."""
@@ -85,6 +87,8 @@ class Client(object):
 
     def privmsg(self, hostmask, target, message):
         """Sends the client a message from someone."""
+        if target not in self.joined_channels:
+            self.join(target)
         for line in message.splitlines():
             if line:
                 self.write(hostmask, 'PRIVMSG', target, ':{}'.format(line))

--- a/pickups/irc.py
+++ b/pickups/irc.py
@@ -1,4 +1,5 @@
 import logging
+from . import util
 
 RPL_WELCOME = 1
 RPL_WHOISUSER = 311
@@ -20,7 +21,8 @@ logger = logging.getLogger(__name__)
 
 class Client(object):
 
-    def __init__(self, reader, writer):
+    def __init__(self, server, reader, writer):
+        self.server = server
         self.reader = reader
         self.writer = writer
 
@@ -65,6 +67,10 @@ class Client(object):
         """Tells the client to join a channel."""
         self.joined_channels.add(channel)
         self.write(self.nickname, 'JOIN', channel)
+        conv = util.channel_to_conversation(channel, self.server._conv_list)
+        self.topic(channel, util.get_topic(conv))
+        self.list_nicks(channel, (util.get_nick(user) for user in conv.users))
+
 
     def list_nicks(self, channel, nicks):
         """Tells the client what nicks are in channel."""

--- a/pickups/server.py
+++ b/pickups/server.py
@@ -112,6 +112,10 @@ class Server(object):
                 client.topic(channel, util.get_topic(conv))
                 client.list_nicks(channel,
                                   (util.get_nick(user) for user in conv.users))
+                client.joined_channels.add(channel)
+            elif line.startswith('PART'):
+                channel = line.split(' ')[1]
+                client.joined_channels.remove(channel)
             elif line.startswith('WHO'):
                 query = line.split(' ')[1]
                 if query.startswith('#'):

--- a/pickups/server.py
+++ b/pickups/server.py
@@ -58,7 +58,7 @@ class Server(object):
 
     def _on_client_connect(self, client_reader, client_writer):
         """Called when an IRC client connects."""
-        client = irc.Client(client_reader, client_writer)
+        client = irc.Client(self, client_reader, client_writer)
         task = asyncio.Task(self._handle_client(client))
         self.clients[task] = client
         logger.info("New Connection")

--- a/pickups/server.py
+++ b/pickups/server.py
@@ -119,6 +119,7 @@ class Server(object):
             elif line.startswith('WHO'):
                 query = line.split(' ')[1]
                 if query.startswith('#'):
+                    channel = line.split(' ')[1]
                     conv = util.channel_to_conversation(channel,
                                                          self._conv_list)
                     responses = [{

--- a/pickups/util.py
+++ b/pickups/util.py
@@ -6,21 +6,23 @@ import re
 
 CONV_HASH_LEN = 7
 
+hashes = {}
 
 def conversation_to_channel(conv):
     """Return channel name for hangups.Conversation."""
     # Must be 50 characters max and not contain space or comma.
-    conv_hash = hashlib.sha1(conv.id_.encode()).hexdigest()
     name = get_conv_name(conv).replace(',', '_').replace(' ', '')
-    return '#{}[{}]'.format(name[:50 - CONV_HASH_LEN - 3],
-                            conv_hash[:CONV_HASH_LEN])
+    name = "#{}".format(name[:49])
+    conv_hash = hashlib.sha1(conv.id_.encode()).hexdigest()
+    hashes[name] = conv_hash
+    return name
 
 
 def channel_to_conversation(channel, conv_list):
     """Return hangups.Conversation for channel name."""
-    conv_hash = re.match(r'^.*\[([a-f0-9]+)\]$', channel).group(1)
-    return {hashlib.sha1(conv.id_.encode()).hexdigest()[:CONV_HASH_LEN]: conv
-            for conv in conv_list.get_all()}[conv_hash]
+    conv_hash = hashes[channel]
+    return {hashlib.sha1(conv.id_.encode()).hexdigest(): conv for conv in
+            conv_list.get_all()}[conv_hash]
 
 
 def get_nick(user):

--- a/pickups/util.py
+++ b/pickups/util.py
@@ -14,6 +14,13 @@ def conversation_to_channel(conv):
     name = get_conv_name(conv).replace(',', '_').replace(' ', '')
     name = "#{}".format(name[:49])
     conv_hash = hashlib.sha1(conv.id_.encode()).hexdigest()
+    # Avoid name collisions.
+    if name in hashes and hashes[name] != conv_hash:
+        while name in hashes:
+            if len(name) > 50:
+                name = "{}_".format(name[:-1])
+            else:
+                name = "{}_".format(name)
     hashes[name] = conv_hash
     return name
 


### PR DESCRIPTION
I can send two separate PRs if you prefer, or if I messed any of the commits up. Cheers.

(The previous commit (#3) had a problem with the collision prevention, this is fixed now.)